### PR TITLE
chore(ci): match release-please signoff to bot author for DCO

### DIFF
--- a/.github/.release-please-config.json
+++ b/.github/.release-please-config.json
@@ -8,7 +8,7 @@
   "pull-request-header": "An automated release has been created for you.",
   "tag-separator": "@",
   "separate-pull-requests": true,
-  "signoff": "Straw Hat Team Bot <61149376+sht-bot@users.noreply.github.com>",
+  "signoff": "SHT Bot <61149376+sht-bot@users.noreply.github.com>",
   "changelog-sections": [
     {
       "type": "feat",


### PR DESCRIPTION
- The DCO check on release-please PRs fails because the configured signoff name ("Straw Hat Team Bot") does not match the bot account's author name ("SHT Bot"), and the DCO probot requires an exact name and email match.